### PR TITLE
Note on Python 3/Unicode strings and Nones

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,11 @@ Currently the following PostgreSQL datatypes are supported:
 * jsonb
 * uuid
 
+Unicode strings in the data to be inserted (all values of type ``str`` in
+Python 3) should be encoded as ``bytes`` before passing them to ``copy``.
+Values intended to be ``NULL`` in the database should be encoded as ``None``
+rather than as empty strings.
+
 .. note::
 
     PostgreSQL numeric does not support ``Decimal('Inf')`` or

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,13 @@ For example::
 By default, a temporary file on disk is used.  If there's enough memory,
 you can get a slight performance benefit with in-memory storage::
 
+    # Python 2
     from cStringIO import StringIO
     mgr.copy(records, StringIO)
+
+    # Python 3
+    from cStringIO import BytesIO
+    mgr.copy(records, BytesIO)
 
 A db schema can be specified in the table name using dot notation::
 


### PR DESCRIPTION
I ran into the same issue as the one mentioned in #5. It makes sense that Python 3 strings need to be encoded as bytes, but the example data given in the documentation is misleading because when run in Python 3 it will lead to this error.

In addition, I had previously been formatting my data for copying into Postgres using the CSV format (where NULL values are represented as empty strings), which led to errors when I tried to use pgcopy. I thought it would be worth making explicit that NULL values should be None in the Python data.