### PR TITLE
Fix import error in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,7 @@ For example::
 By default, a temporary file on disk is used.  If there's enough memory,
 you can get a slight performance benefit with in-memory storage::
 
-    # Python 2
-    from cStringIO import StringIO
-    mgr.copy(records, StringIO)
-
-    # Python 3
-    from cStringIO import BytesIO
+    from io import BytesIO
     mgr.copy(records, BytesIO)
 
 A db schema can be specified in the table name using dot notation::


### PR DESCRIPTION
Hi again, just realized I made an embarrassing error in the snippet I added to the docs--there's no cStringIO in Python 3, of course. "from io import BytesIO" works in both Python 2 and 3. Using BytesIO in both 2/3 is probably the most straightforward approach.