### PR TITLE
Update setup.py to draw from psycopg2-binary.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license = 'MIT',
     url = "https://github.com/altaurog/pgcopy",
     packages = [package_name],
-    install_requires = ["psycopg2", "pytz"],
+    install_requires = ["psycopg2-binary", "pytz"],
     classifiers = [
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
You can no longer `pip install psycopg2`, and must instead install `psycopg2-binary`. Currently we are unable to `pip install pgcopy` as a result.