### PR TITLE
#19 Adding the time datatype

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ with contributions from
 * Marcin Gozdalik `@gozdal <https://github.com/gozdal>`_
 * John A. Bachman `@johnbachman <https://github.com/johnbachman>`_
 * Akshaye Shenoi `@akshayeshenoi <https://github.com/akshayeshenoi>`_
+* Nathan Glover `@nathanglover <https://github.com/nathanglover>`_

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ pgcopy supports the following PostgreSQL scalar types:
 * text
 * bytea
 * date
+* time
 * timestamp
 * timestamp with time zone
 * numeric

--- a/docs/datatypes.rst
+++ b/docs/datatypes.rst
@@ -22,6 +22,7 @@ varchar                    str, bytes        Encoding_, Truncation_
 text                       str, bytes        Encoding_, Truncation_
 bytea                      bytes             Truncation_
 date                       datetime.date
+time                       datetime.time
 timestamp                  datetime.datetime
 timestamp with time zone   datetime.datetime
 numeric                    decimal.Decimal   Numeric_

--- a/pgcopy/copy.py
+++ b/pgcopy/copy.py
@@ -5,7 +5,7 @@ import struct
 import tempfile
 import threading
 
-from datetime import date
+from datetime import date, datetime
 
 try:
     from itertools import izip as zip
@@ -43,6 +43,12 @@ def timestamp(dt):
     # see http://stackoverflow.com/a/14369386/519015
     val = ((unix_timestamp - psql_epoch) * 1000000) + dt.microsecond
     return ('iq', (8, val))
+
+def time_formatter(t):
+    'get microseconds since 2000-01-01 00:00'
+    t = util.to_utc_time(t)
+    dt = datetime.combine(psql_epoch_date, t)
+    return timestamp(dt)
 
 def datestamp(d):
     'days since 2000-01-01'
@@ -116,6 +122,7 @@ type_formatters = {
     'json': str_formatter,
     'jsonb': jsonb_formatter,
     'date': datestamp,
+    'time': time_formatter,
     'timestamp': timestamp,
     'timestamptz': timestamp,
     'numeric': numeric,

--- a/pgcopy/util.py
+++ b/pgcopy/util.py
@@ -1,7 +1,7 @@
 import re
 import random
 import string
-from datetime import datetime
+from datetime import datetime, time
 from pytz import UTC
 
 def array_info(arr):
@@ -45,6 +45,12 @@ def to_utc(dt):
         return UTC.localize(dt)
     else:
         return dt.astimezone(UTC)
+
+def to_utc_time(t):
+    if not isinstance(t, time):
+        t = time(t.hour, t.minute, t.second, t.microsecond)
+    
+    return UTC.localize(t)
 
 source = string.ascii_lowercase + string.digits
 def uid():

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,4 +1,5 @@
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, time, timedelta
+from random import randint
 import hashlib
 
 from pgcopy import util
@@ -8,6 +9,7 @@ genbool = lambda i: 0 == (i % 3)
 genint = lambda i: i
 genfloat = lambda i: 1.125 * i
 gendate = lambda i: date(1708, 1, 1) + timedelta(i % (250 * 365))
+gentime = lambda i: time(randint(0, 23), randint(0, 59), randint(0, 59), randint(0, 999999))
 gendatetime = lambda i: datetime(1970, 1, 1) + timedelta(hours=i)
 gendatetimetz = lambda i: util.to_utc(datetime(1970, 1, 1) + timedelta(hours=i))
 genstr12 = lambda i: hashlib.md5(str(i).encode()).hexdigest()[:12 - (i % 3)].encode()
@@ -20,6 +22,7 @@ datagen = {
         'real': genfloat,
         'double precision': genfloat,
         'date': gendate,
+        'time': gentime,
         'timestamp': gendatetime,
         'timestamp with time zone': gendatetimetz,
         'varchar(12)': genstr12,

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -199,6 +199,9 @@ class TestBytea(TypeMixin):
         assert isinstance(v, memoryview)
         return bytes(v)
 
+class TestTime(TypeMixin):
+    datatypes = ['time']
+
 class TestTimestamp(TypeMixin):
     datatypes = ['timestamp']
 


### PR DESCRIPTION
I believe this closes #19.

Tests pass on the version of Python I was using (3.8.1, [the latest from Docker](https://hub.docker.com/_/python)). I was unable to test with tox to test all other versions. 

Here is the formatter:
```python
def time_formatter(t):
    'get microseconds since 2000-01-01 00:00'
    t = util.to_utc_time(t)
    dt = datetime.combine(psql_epoch_date, t)
    return timestamp(dt)
```

It uses the `psql_epoch_date` variable and the already built timestamp formatter to get the number of microseconds since 2000-01-01 00:00 for the given `datetime.time` object.

I spent a little bit of time trying to figure out how to get "time with time zone" to work, but couldn't figure it out ultimately. 

I also updated the documentation to include the new `time` datatype. Let me know if I need to add anything else.