### PR TITLE
Add support for `vector` datatype

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ with contributions from
 * John A. Bachman `@johnbachman <https://github.com/johnbachman>`_
 * Akshaye Shenoi `@akshayeshenoi <https://github.com/akshayeshenoi>`_
 * Nathan Glover `@nathanglover <https://github.com/nathanglover>`_
+* William Burklund `@wburklund <https://github.com/wburklund>`_

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ pgcopy supports the following PostgreSQL scalar types:
 * jsonb
 * uuid
 * arrays
+* vector
 
 Documentation
 --------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - pgsql
 
   pgsql:
-    image: postgres:12
+    image: pgvector/pgvector:pg12
     environment:
       - POSTGRES_DB=pgcopy_test
       - POSTGRES_USER=postgres

--- a/docs/datatypes.rst
+++ b/docs/datatypes.rst
@@ -30,6 +30,7 @@ numeric                    decimal.Decimal   Numeric_
 json                       str, bytes        Encoding_
 jsonb                      bytes
 uuid                       uuid.UUID
+vector                     list[float]       Vector_
 ========================== ================= =========================
 
 Arrays
@@ -53,3 +54,7 @@ Numeric
 """"""""
 PostgreSQL numeric does not support ``Decimal('Inf')`` or
 ``Decimal('-Inf')``.  pgcopy serializes these as ``NaN``.
+
+Vector
+*******
+From `pgvector <https://github.com/pgvector/pgvector>`_.

--- a/pgcopy/copy.py
+++ b/pgcopy/copy.py
@@ -115,6 +115,19 @@ def uuid_formatter(guid):
     return "i2Q", (16, (guid.int >> 64) & MAX_INT64, guid.int & MAX_INT64)
 
 
+def vector_formatter(val):
+    info = util.array_info(val)
+    ndim, lengths = info[0], info[1:]
+    if ndim != 1:
+        raise ValueError("{} is not a 1D array type".format(val))
+
+    # https://github.com/pgvector/pgvector/blob/587e9ba97c1cb057117bc9b081c0170b5013f8d8/src/vector.c#L402-L419
+    fmt = ">hh" + "f" * lengths[0]
+    data = [lengths[0], 0, *val]
+
+    return str_formatter(struct.pack(fmt, *data))
+
+
 type_formatters = {
     "bool": simple_formatter("?"),
     "int2": simple_formatter("h"),
@@ -134,6 +147,7 @@ type_formatters = {
     "timestamptz": timestamp,
     "numeric": numeric,
     "uuid": uuid_formatter,
+    "vector": vector_formatter,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ connection_params = {
 @pytest.fixture(scope="session")
 def db():
     drop = create_db()
+    load_extensions()
     yield
     if drop:
         try:
@@ -60,6 +61,15 @@ def create_db():
                 raise RuntimeError(message)
             else:
                 return True
+
+
+def load_extensions():
+    conn = connect()
+    cur = conn.cursor()
+    try:
+        cur.execute("CREATE EXTENSION vector")
+    except psycopg2.errors.DuplicateObject:
+        pass
 
 
 def drop_db():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def load_extensions():
     cur = conn.cursor()
     try:
         cur.execute("CREATE EXTENSION vector")
-    except psycopg2.errors.DuplicateObject:
+    except:
         pass
 
 

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,6 +1,6 @@
 import hashlib
 from datetime import date, datetime, time, timedelta
-from random import randint, uniform
+from random import randint
 
 from pgcopy import util
 
@@ -14,7 +14,6 @@ gentime = lambda i: time(
 gendatetime = lambda i: datetime(1970, 1, 1) + timedelta(hours=i)
 gendatetimetz = lambda i: util.to_utc(datetime(1970, 1, 1) + timedelta(hours=i))
 genstr12 = lambda i: hashlib.md5(str(i).encode()).hexdigest()[: 12 - (i % 3)].encode()
-genvector = lambda i: [uniform(-i, i)]
 
 datagen = {
     "bool": genbool,
@@ -29,7 +28,6 @@ datagen = {
     "timestamp with time zone": gendatetimetz,
     "varchar(12)": genstr12,
     "char(12)": genstr12,
-    "vector": genvector,
 }
 
 colname = lambda i: chr(ord("a") + i)

--- a/tests/db.py
+++ b/tests/db.py
@@ -1,6 +1,6 @@
 import hashlib
 from datetime import date, datetime, time, timedelta
-from random import randint
+from random import randint, uniform
 
 from pgcopy import util
 
@@ -14,6 +14,7 @@ gentime = lambda i: time(
 gendatetime = lambda i: datetime(1970, 1, 1) + timedelta(hours=i)
 gendatetimetz = lambda i: util.to_utc(datetime(1970, 1, 1) + timedelta(hours=i))
 genstr12 = lambda i: hashlib.md5(str(i).encode()).hexdigest()[: 12 - (i % 3)].encode()
+genvector = lambda i: [uniform(-i, i)]
 
 datagen = {
     "bool": genbool,
@@ -28,6 +29,7 @@ datagen = {
     "timestamp with time zone": gendatetimetz,
     "varchar(12)": genstr12,
     "char(12)": genstr12,
+    "vector": genvector,
 }
 
 colname = lambda i: chr(ord("a") + i)

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -293,3 +293,13 @@ class TestEnum(TypeMixin):
     extra_sql = "CREATE TYPE test_enum AS ENUM ('one', 'two', 'three')"
     datatypes = ["test_enum"]
     data = [("one",), ("two",), ("three",)]
+
+
+class TestVector(TypeMixin):
+    datatypes = ["vector"]
+    data = [
+        ((-1.5, 0, 2.3),),
+    ]
+
+    def cast(self, v):
+        return tuple(json.loads(v))


### PR DESCRIPTION
Thanks for creating this library.

This patch adds support for the `vector` datatype introduced by the [pgvector](https://github.com/pgvector/pgvector) extension. Pgvector adds vector database functionality to PostgreSQL, making it suitable for AI applications such as semantic search and RAG. It is supported by AWS, Azure, and Google Cloud in their managed PostgreSQL offerings.

As an ML engineer, this patch is useful to me. I hope it helps others as well.

